### PR TITLE
RID-8707: Add min-release-age=7d to protect against supply chain attacks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
+      - name: Set min-release-age
+        run: echo "min-release-age=7d" >> .npmrc
+
       - name: Install yarn
         run: npm install --global yarn
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Set min-release-age
+        run: echo "min-release-age=7d" >> .npmrc
+
       - name: Install yarn
         run: npm install --global yarn
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7d


### PR DESCRIPTION
Set npm min-release-age=7d in CI workflows and .npmrc to prevent installing package versions published less than 7 days ago.

Made-with: Cursor